### PR TITLE
Add a div with some height to give the template white space on preview

### DIFF
--- a/builds/development/templates/blank.html
+++ b/builds/development/templates/blank.html
@@ -205,6 +205,7 @@
     </div>
     <main id="main" class="content">
         <!-- your content here -->
+        <div style="height: 500px;"></div>
     </main>
 
     <div class="footer">

--- a/builds/production/templates/blank.html
+++ b/builds/production/templates/blank.html
@@ -11,6 +11,10 @@
     <meta content="width=device-width, user-scalable=no" name="viewport" />
     <link href="https://www.purdue.edu/purdue/images/favicon.ico" rel="shortcut icon" />
     <link rel="stylesheet" text="text/css" href="../css/blank/blank-1.0.0.css" />
+
+
+    <link href="https://fonts.googleapis.com/css?family=Archivo+Narrow:400,700" rel="stylesheet" />
+
     <noscript>
         <link rel="stylesheet" href="https://use.fontawesome.com/c2da24ec3a.css">
     </noscript>
@@ -201,6 +205,7 @@
     </div>
     <main id="main" class="content">
         <!-- your content here -->
+        <div style="height: 500px;"></div>
     </main>
 
     <div class="footer">

--- a/components/html/modules/content-blank/_all.html
+++ b/components/html/modules/content-blank/_all.html
@@ -1,3 +1,4 @@
 <main id="main" class="content">
 	<!-- your content here -->
+    <div style="height: 500px;"></div>
 </main>


### PR DESCRIPTION
Currently, when you load the page preview of the blank page you see:

![screen shot 2018-02-22 at 2 40 33 pm](https://user-images.githubusercontent.com/5982996/36560326-6540abec-17de-11e8-9f1d-6735c656ce2b.png)

This update adds an empty div with inline style of 500px to give some white space so it more accurately reflects the thumbnail like this:

![screen shot 2018-02-22 at 2 42 32 pm](https://user-images.githubusercontent.com/5982996/36560424-aa4a7506-17de-11e8-9d19-797a5a3b1cf0.png)
