### PR TITLE
Remove Champion css link

### DIFF
--- a/components/html/modules/head/_css.html
+++ b/components/html/modules/head/_css.html
@@ -10,4 +10,4 @@
 }
 <noscript>
 	<link rel="stylesheet" href="https://use.fontawesome.com/c2da24ec3a.css">
-</noscript>
+</noscript> 


### PR DESCRIPTION
Champion font-families are loaded in each page's css.